### PR TITLE
Vagrant update to travis, adding extra parameters for service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ services:
   - docker
 
 install:
-  - wget https://releases.hashicorp.com/vagrant/2.0.4/vagrant_2.0.4_x86_64.deb
-  - sudo apt install ./vagrant_2.0.4_x86_64.deb -y
+  - wget https://releases.hashicorp.com/vagrant/2.1.1/vagrant_2.1.1_x86_64.deb
+  - sudo apt install ./vagrant_2.1.1_x86_64.deb -y
   - pip install -U pip wheel
   - pip install ansible
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,3 +22,4 @@ devpi_listen_address: "127.0.0.1"                     # This needs to be set to 
 devpi_listen_port: 9000                               # Port that the devpi service listens on
 devpi_test_package: pluggy                            # This is the upstream package we force remove and reinstall to test things are working
 devpi_proxy: ""                                       # Hard code specific proxy into the service file
+devpi_additional_parameters: []                       # Extra paramaters, these will be passed to the devpi-server when it starts

--- a/templates/devpi_proxy.service.j2
+++ b/templates/devpi_proxy.service.j2
@@ -9,7 +9,7 @@ EnvironmentFile=/etc/environment
 Environment=http_proxy={{ devpi_proxy }}
 Environment=https_proxy={{ devpi_proxy }}
 {% endif %}
-ExecStart=/usr/local/bin/devpi-server --host={{ devpi_listen_address }} --port={{ devpi_listen_port }}
+ExecStart=/usr/local/bin/devpi-server --host={{ devpi_listen_address }} --port={{ devpi_listen_port }} {{ devpi_additional_parameters|join(' ') }}
 Restart=always
 RestartSec=2
 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -17,6 +17,9 @@
     devpi_listen_address: "0.0.0.0"
     # Set up proxy to allow devpi to get packages
     devpi_proxy: "{{ lookup('env','http_proxy') }}"
+    # Extra test parameters
+    devpi_additional_parameters:
+      - "--mirror-cache-expiry 1800"
   roles:
     - role: "{{ playbook_dir | dirname }}"
   environment: "{{ proxy_env }}"


### PR DESCRIPTION
Updated to the latest version of vagrant and added the option to add additional parameters to the devpi proxy service.